### PR TITLE
#6: Fixed `Route::$hasTrailingSlash` value loss during route caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Laravel URL Route Trailing Slash
 ================================
 
+1.1.5 Under Development
+-----------------------
+
+- Bug #6: Fixed `Route::$hasTrailingSlash` value loss during route caching with "illuminate/routing" >= 7.0 (klimov-paul)
+
+
 1.1.4, April 23, 2020
 ---------------------
 

--- a/src/CompiledRouteCollection.php
+++ b/src/CompiledRouteCollection.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link https://github.com/illuminatech
+ * @copyright Copyright (c) 2019 Illuminatech
+ * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+ */
+
+namespace Illuminatech\UrlTrailingSlash;
+
+use Illuminate\Routing\CompiledRouteCollection as BaseCompiledRouteCollection;
+
+/**
+ * CompiledRouteCollection is an enhanced version of {@see \Illuminate\Routing\CompiledRouteCollection}, which allows
+ * restoration of trailing slashes definition from cached routes.
+ *
+ * @see \Illuminatech\UrlTrailingSlash\Route
+ * @see \Illuminate\Foundation\Console\RouteCacheCommand
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 1.1.5
+ */
+class CompiledRouteCollection extends BaseCompiledRouteCollection
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function newRoute(array $attributes)
+    {
+        $route = parent::newRoute($attributes);
+
+        if (array_key_exists('hasTrailingSlash', $attributes)) {
+            $route->hasTrailingSlash = $attributes['hasTrailingSlash'];
+        }
+
+        return $route;
+    }
+}

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @link https://github.com/illuminatech
+ * @copyright Copyright (c) 2019 Illuminatech
+ * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+ */
+
+namespace Illuminatech\UrlTrailingSlash;
+
+use Illuminate\Routing\RouteCollection as BaseRouteCollection;
+
+/**
+ * RouteCollection is an enhanced version of {@see \Illuminate\Routing\RouteCollection}, which allows saving trailing
+ * slashes definition while caching routes.
+ *
+ * @see \Illuminatech\UrlTrailingSlash\Route
+ * @see \Illuminate\Foundation\Console\RouteCacheCommand
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 1.1.5
+ */
+class RouteCollection extends BaseRouteCollection
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        $compiled = parent::compile();
+
+        foreach ($this->getRoutes() as $route) {
+            if (! $route instanceof Route) {
+                continue;
+            }
+
+            $compiled['attributes'][$route->getName()]['hasTrailingSlash'] = $route->hasTrailingSlash;
+        }
+
+        return $compiled;
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -7,6 +7,8 @@
 
 namespace Illuminatech\UrlTrailingSlash;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Routing\PendingResourceRegistration;
 use Illuminate\Routing\ResourceRegistrar as BaseResourceRegistrar;
 use Illuminate\Routing\Router as BaseRouter;
@@ -22,6 +24,16 @@ use Illuminate\Support\Str;
  */
 class Router extends BaseRouter
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Dispatcher $events, Container $container = null)
+    {
+        parent::__construct($events, $container);
+
+        $this->routes = new RouteCollection;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -71,5 +83,17 @@ class Router extends BaseRouter
         return new PendingResourceRegistration(
             $registrar, $name, $controller, $options
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCompiledRoutes(array $routes)
+    {
+        $this->routes = (new CompiledRouteCollection($routes['compiled'], $routes['attributes']))
+            ->setRouter($this)
+            ->setContainer($this->container);
+
+        $this->container->instance('routes', $this->routes);
     }
 }

--- a/tests/CompiledRouteCollectionTest.php
+++ b/tests/CompiledRouteCollectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminatech\UrlTrailingSlash\Test;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminatech\UrlTrailingSlash\CompiledRouteCollection;
+use Illuminatech\UrlTrailingSlash\Router;
+
+class CompiledRouteCollectionTest extends TestCase
+{
+    /**
+     * @return Router test router instance.
+     */
+    protected function createRouter()
+    {
+        $container = new Container();
+
+        $router = new Router(new Dispatcher, $container);
+
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        return $router;
+    }
+
+    public function testRestoreRouteFromComplied()
+    {
+        $router = $this->createRouter();
+
+        $router->get('foo/bar/', function () {
+            return 'with trailing slash';
+        })->name('foo.bar');
+
+        $compiled = $router->getRoutes()->compile();
+
+        $routeCollection = new CompiledRouteCollection($compiled['compiled'], $compiled['attributes']);
+
+        $routeCollection->setRouter($router);
+        $routeCollection->setContainer(Container::getInstance());
+
+        $route = $routeCollection->getByName('foo.bar');
+
+        $this->assertTrue($route->hasTrailingSlash);
+    }
+}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -116,4 +116,20 @@ class RouterTest extends TestCase
         $this->assertTrue($routes[0]->hasTrailingSlash);
         $this->assertFalse($routes[1]->hasTrailingSlash);
     }
+
+    /**
+     * @depends testAddRoute
+     */
+    public function testCompile()
+    {
+        $router = $this->createRouter();
+
+        $router->get('foo/bar/', function () {
+            return 'with trailing slash';
+        })->name('foo.bar');
+
+        $compiled = $router->getRoutes()->compile();
+
+        $this->assertTrue($compiled['attributes']['foo.bar']['hasTrailingSlash']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #6