### PR TITLE
Fix: missing explicit nullable type hint

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -27,7 +27,7 @@ class Router extends BaseRouter
     /**
      * {@inheritdoc}
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, ?Container $container = null)
     {
         parent::__construct($events, $container);
 


### PR DESCRIPTION
Implicitly marking parameter $container as nullable is deprecated in PHP 8.4.

Fixes the PHP 8.4 deprecation where the explicit nullable type must be used.

`Deprecated: Illuminatech\UrlTrailingSlash\Router::__construct(): Implicitly marking parameter $container as nullable is deprecated, the explicit nullable type must be used instead in vendor/illuminatech/url-trailing-slash/src/Router.php on line 30`


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 