### PR TITLE
Fixed trailing slash handling in UrlGenerator for root path

### DIFF
--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -53,7 +53,7 @@ class UrlGenerator extends BaseUrlGenerator
 
         $url = parent::to($path, $extra, $secure);
 
-        if (Str::endsWith($path, '/')) {
+        if (Str::endsWith($path, '/') && $path !== '/') {
             return $url.'/';
         }
 

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -16,6 +16,10 @@ class UrlGeneratorTest extends TestCase
             Request::create('http://www.example.com/')
         );
 
+        $this->assertEquals('http://www.example.com/', $urlGenerator->to('/'));
+        $this->assertEquals('http://www.example.com/foo/', $urlGenerator->to('foo/'));
+        $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar/'));
+
         $this->assertEquals('http://www.example.com/foo/bar', $urlGenerator->to('foo/bar'));
         $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar/'));
         $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar//'));

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -18,8 +18,6 @@ class UrlGeneratorTest extends TestCase
 
         $this->assertEquals('http://www.example.com/', $urlGenerator->to('/'));
         $this->assertEquals('http://www.example.com/foo/', $urlGenerator->to('foo/'));
-        $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar/'));
-
         $this->assertEquals('http://www.example.com/foo/bar', $urlGenerator->to('foo/bar'));
         $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar/'));
         $this->assertEquals('http://www.example.com/foo/bar/', $urlGenerator->to('foo/bar//'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Fixed trailing slash handling in UrlGenerator for root path. Now `$urlGenerator->to('/')` returns `http://www.example.com//`